### PR TITLE
refactor: add context parameters to inner functions

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -1,8 +1,6 @@
 package base
 
-import (
-	"github.com/dennwc/base"
-)
+import "context"
 
 // DB is a common interface implemented by all database abstractions.
 type DB interface {
@@ -11,7 +9,20 @@ type DB interface {
 }
 
 // Tx is a common interface implemented by all transactions.
-type Tx = base.Tx
+type Tx interface {
+	// Commit applies all changes made in the transaction.
+	Commit(ctx context.Context) error
+	// Close rolls back the transaction.
+	// Committed transactions will not be affected by calling Close.
+	Close() error
+}
 
 // Iterator is a common interface implemented by all iterators.
-type Iterator = base.IteratorContext
+type Iterator interface {
+	// Next advances an iterator.
+	Next(ctx context.Context) bool
+	// Err returns a last encountered error.
+	Err() error
+	// Close frees resources.
+	Close() error
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go/datastore v1.6.0
 	github.com/boltdb/bolt v1.3.1
 	github.com/cockroachdb/pebble v0.0.0-20220318150003-0ad186894f6d
-	github.com/dennwc/base v1.0.0
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/go-kivik/couchdb v2.0.0+incompatible
 	github.com/go-kivik/kivik v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,6 @@ github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dennwc/base v1.0.0 h1:xlBzvBNRvkQ1LFI/jom7rr0vZsvYDKtvMM6lIpjFb3M=
-github.com/dennwc/base v1.0.0/go.mod h1:zaTDIiAcg2oKW9XhjIaRc1kJVteCFXSSW6jwmCedUaI=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=

--- a/kv/bbolt/bolt.go
+++ b/kv/bbolt/bolt.go
@@ -75,7 +75,7 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
-func (db *DB) Tx(rw bool) (kv.Tx, error) {
+func (db *DB) Tx(ctx context.Context, rw bool) (kv.Tx, error) {
 	tx, err := db.db.Begin(rw)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func (tx *Tx) Close() error {
 	return tx.tx.Rollback()
 }
 
-func (tx *Tx) Put(k kv.Key, v kv.Value) error {
+func (tx *Tx) Put(ctx context.Context, k kv.Key, v kv.Value) error {
 	var (
 		b   *bolt.Bucket
 		err error
@@ -171,7 +171,7 @@ func (tx *Tx) Put(k kv.Key, v kv.Value) error {
 	return err
 }
 
-func (tx *Tx) Del(k kv.Key) error {
+func (tx *Tx) Del(ctx context.Context, k kv.Key) error {
 	b, k := tx.bucket(k)
 	if b == nil || len(k) != 1 {
 		return nil
@@ -183,7 +183,7 @@ func (tx *Tx) Del(k kv.Key) error {
 	return err
 }
 
-func (tx *Tx) Scan(opts ...kv.IteratorOption) kv.Iterator {
+func (tx *Tx) Scan(ctx context.Context, opts ...kv.IteratorOption) kv.Iterator {
 	var it kv.Iterator = &Iterator{
 		tx:    tx,
 		rootb: tx.root(),

--- a/kv/bolt/bolt.go
+++ b/kv/bolt/bolt.go
@@ -75,7 +75,7 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
-func (db *DB) Tx(rw bool) (kv.Tx, error) {
+func (db *DB) Tx(ctx context.Context, rw bool) (kv.Tx, error) {
 	tx, err := db.db.Begin(rw)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func (tx *Tx) Close() error {
 	return tx.tx.Rollback()
 }
 
-func (tx *Tx) Put(k kv.Key, v kv.Value) error {
+func (tx *Tx) Put(ctx context.Context, k kv.Key, v kv.Value) error {
 	var (
 		b   *bolt.Bucket
 		err error
@@ -171,7 +171,7 @@ func (tx *Tx) Put(k kv.Key, v kv.Value) error {
 	return err
 }
 
-func (tx *Tx) Del(k kv.Key) error {
+func (tx *Tx) Del(ctx context.Context, k kv.Key) error {
 	b, k := tx.bucket(k)
 	if b == nil || len(k) != 1 {
 		return nil
@@ -183,7 +183,7 @@ func (tx *Tx) Del(k kv.Key) error {
 	return err
 }
 
-func (tx *Tx) Scan(opts ...kv.IteratorOption) kv.Iterator {
+func (tx *Tx) Scan(ctx context.Context, opts ...kv.IteratorOption) kv.Iterator {
 	var it kv.Iterator = &Iterator{
 		tx:    tx,
 		rootb: tx.root(),

--- a/kv/flat/badger/badger.go
+++ b/kv/flat/badger/badger.go
@@ -66,7 +66,7 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
-func (db *DB) Tx(rw bool) (flat.Tx, error) {
+func (db *DB) Tx(ctx context.Context, rw bool) (flat.Tx, error) {
 	tx := db.db.NewTransaction(rw)
 	return &Tx{tx: tx}, nil
 }
@@ -113,7 +113,7 @@ func (tx *Tx) GetBatch(ctx context.Context, keys []flat.Key) ([]flat.Value, erro
 	return flat.GetBatch(ctx, tx, keys)
 }
 
-func (tx *Tx) Put(k flat.Key, v flat.Value) error {
+func (tx *Tx) Put(ctx context.Context, k flat.Key, v flat.Value) error {
 	err := tx.tx.Set(k, v)
 	if err == badger.ErrConflict {
 		err = flat.ErrConflict
@@ -121,7 +121,7 @@ func (tx *Tx) Put(k flat.Key, v flat.Value) error {
 	return err
 }
 
-func (tx *Tx) Del(k flat.Key) error {
+func (tx *Tx) Del(ctx context.Context, k flat.Key) error {
 	err := tx.tx.Delete(k)
 	if err == badger.ErrConflict {
 		err = flat.ErrConflict
@@ -129,7 +129,7 @@ func (tx *Tx) Del(k flat.Key) error {
 	return err
 }
 
-func (tx *Tx) Scan(opts ...flat.IteratorOption) flat.Iterator {
+func (tx *Tx) Scan(ctx context.Context, opts ...flat.IteratorOption) flat.Iterator {
 	bit := tx.tx.NewIterator(badger.DefaultIteratorOptions)
 	var it flat.Iterator = &Iterator{it: bit, first: true}
 	it = flat.ApplyIteratorOptions(it, opts)

--- a/kv/flat/btree/btree.go
+++ b/kv/flat/btree/btree.go
@@ -58,7 +58,7 @@ func (db *DB) Close() error {
 	return nil
 }
 
-func (db *DB) Tx(rw bool) (flat.Tx, error) {
+func (db *DB) Tx(ctx context.Context, rw bool) (flat.Tx, error) {
 	return &Tx{t: db.t, rw: rw}, nil
 }
 
@@ -101,7 +101,7 @@ func (tx *Tx) Close() error {
 	return nil
 }
 
-func (tx *Tx) Put(k flat.Key, v flat.Value) error {
+func (tx *Tx) Put(ctx context.Context, k flat.Key, v flat.Value) error {
 	if !tx.rw {
 		return flat.ErrReadOnly
 	}
@@ -109,7 +109,7 @@ func (tx *Tx) Put(k flat.Key, v flat.Value) error {
 	return nil
 }
 
-func (tx *Tx) Del(k flat.Key) error {
+func (tx *Tx) Del(ctx context.Context, k flat.Key) error {
 	if !tx.rw {
 		return flat.ErrReadOnly
 	}
@@ -117,7 +117,7 @@ func (tx *Tx) Del(k flat.Key) error {
 	return nil
 }
 
-func (tx *Tx) Scan(opts ...flat.IteratorOption) flat.Iterator {
+func (tx *Tx) Scan(ctx context.Context, opts ...flat.IteratorOption) flat.Iterator {
 	var it flat.Iterator = &Iterator{t: tx.t}
 	it = flat.ApplyIteratorOptions(it, opts)
 	return it

--- a/kv/flat/btree/btree_test.go
+++ b/kv/flat/btree/btree_test.go
@@ -11,5 +11,8 @@ import (
 func TestBtree(t *testing.T) {
 	kvtest.RunTest(t, func(t testing.TB) kv.KV {
 		return flat.Upgrade(New())
-	}, nil)
+	}, &kvtest.Options{
+		NoLocks: true,
+		NoTx:    true,
+	})
 }

--- a/kv/flat/helpers.go
+++ b/kv/flat/helpers.go
@@ -7,7 +7,7 @@ import "context"
 func Update(ctx context.Context, kv KV, update func(tx Tx) error) error {
 	for {
 		err := func() error {
-			tx, err := kv.Tx(true)
+			tx, err := kv.Tx(ctx, true)
 			if err != nil {
 				return err
 			}
@@ -29,7 +29,7 @@ func Update(ctx context.Context, kv KV, update func(tx Tx) error) error {
 
 // View is a helper to open a read-only transaction to read the database.
 func View(ctx context.Context, kv KV, view func(tx Tx) error) error {
-	tx, err := kv.Tx(false)
+	tx, err := kv.Tx(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func View(ctx context.Context, kv KV, view func(tx Tx) error) error {
 // Each is a helper to enumerate all key-value pairs with a specific prefix.
 // See Iterator for rules of using returned values.
 func Each(ctx context.Context, tx Tx, fnc func(k Key, v Value) error, opts ...IteratorOption) error {
-	it := tx.Scan(opts...)
+	it := tx.Scan(ctx, opts...)
 	defer it.Close()
 	for it.Next(ctx) {
 		if err := fnc(it.Key(), it.Val()); err != nil {

--- a/kv/flat/kv.go
+++ b/kv/flat/kv.go
@@ -22,7 +22,7 @@ var (
 // KV is an interface for flat key-value databases.
 type KV interface {
 	base.DB
-	Tx(rw bool) (Tx, error)
+	Tx(ctx context.Context, rw bool) (Tx, error)
 	View(ctx context.Context, fn func(tx Tx) error) error
 	Update(ctx context.Context, fn func(tx Tx) error) error
 }
@@ -69,11 +69,11 @@ type Tx interface {
 	// Put writes a key-value pair to the database.
 	// New value will immediately be visible by Get on the same Tx,
 	// but implementation might buffer the write until transaction is committed.
-	Put(k Key, v Value) error
+	Put(ctx context.Context, k Key, v Value) error
 	// Del removes the key from the database. See Put for consistency guaranties.
-	Del(k Key) error
+	Del(ctx context.Context, k Key) error
 	// Scan starts iteration over key-value pairs. Returned results are affected by IteratorOption.
-	Scan(opts ...IteratorOption) Iterator
+	Scan(ctx context.Context, opts ...IteratorOption) Iterator
 }
 
 // GetBatch is an implementation of Tx.GetBatch for databases that has no native implementation for it.

--- a/kv/flat/leveldb/leveldb.go
+++ b/kv/flat/leveldb/leveldb.go
@@ -80,7 +80,7 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
-func (db *DB) Tx(rw bool) (flat.Tx, error) {
+func (db *DB) Tx(ctx context.Context, rw bool) (flat.Tx, error) {
 	tx := &Tx{db: db}
 	var err error
 	if rw {
@@ -152,21 +152,21 @@ func (tx *Tx) GetBatch(ctx context.Context, keys []flat.Key) ([]flat.Value, erro
 	return flat.GetBatch(ctx, tx, keys)
 }
 
-func (tx *Tx) Put(k flat.Key, v flat.Value) error {
+func (tx *Tx) Put(ctx context.Context, k flat.Key, v flat.Value) error {
 	if tx.tx == nil {
 		return flat.ErrReadOnly
 	}
 	return tx.tx.Put(k, v, tx.db.wo)
 }
 
-func (tx *Tx) Del(k flat.Key) error {
+func (tx *Tx) Del(ctx context.Context, k flat.Key) error {
 	if tx.tx == nil {
 		return flat.ErrReadOnly
 	}
 	return tx.tx.Delete(k, tx.db.wo)
 }
 
-func (tx *Tx) Scan(opts ...flat.IteratorOption) flat.Iterator {
+func (tx *Tx) Scan(ctx context.Context, opts ...flat.IteratorOption) flat.Iterator {
 	lit := &Iterator{tx: tx}
 	lit.WithPrefix(nil)
 	var it flat.Iterator = lit

--- a/kv/flat/pebble/pebble.go
+++ b/kv/flat/pebble/pebble.go
@@ -60,7 +60,7 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
-func (db *DB) Tx(rw bool) (flat.Tx, error) {
+func (db *DB) Tx(ctx context.Context, rw bool) (flat.Tx, error) {
 	return &Tx{tx: db.db.NewIndexedBatch(), rw: rw}, nil
 }
 
@@ -109,21 +109,21 @@ func (tx *Tx) GetBatch(ctx context.Context, keys []flat.Key) ([]flat.Value, erro
 	return flat.GetBatch(ctx, tx, keys)
 }
 
-func (tx *Tx) Put(k flat.Key, v flat.Value) error {
+func (tx *Tx) Put(ctx context.Context, k flat.Key, v flat.Value) error {
 	if !tx.rw {
 		return flat.ErrReadOnly
 	}
 	return tx.tx.Set(k, v, pebble.Sync)
 }
 
-func (tx *Tx) Del(k flat.Key) error {
+func (tx *Tx) Del(ctx context.Context, k flat.Key) error {
 	if !tx.rw {
 		return flat.ErrReadOnly
 	}
 	return tx.tx.Delete(k, pebble.Sync)
 }
 
-func (tx *Tx) Scan(opts ...flat.IteratorOption) flat.Iterator {
+func (tx *Tx) Scan(ctx context.Context, opts ...flat.IteratorOption) flat.Iterator {
 	pit := tx.tx.NewIter(nil)
 	var it flat.Iterator = &Iterator{it: pit, first: true}
 	it = flat.ApplyIteratorOptions(it, opts)

--- a/kv/flat/upgrade.go
+++ b/kv/flat/upgrade.go
@@ -79,8 +79,8 @@ func (hkv *hieKV) Close() error {
 	return hkv.flat.Close()
 }
 
-func (hkv *hieKV) Tx(rw bool) (kv.Tx, error) {
-	tx, err := hkv.flat.Tx(rw)
+func (hkv *hieKV) Tx(ctx context.Context, rw bool) (kv.Tx, error) {
+	tx, err := hkv.flat.Tx(ctx, rw)
 	if err != nil {
 		return nil, err
 	}
@@ -128,21 +128,21 @@ func (tx *flatTx) Close() error {
 	return tx.tx.Close()
 }
 
-func (tx *flatTx) Put(k kv.Key, v kv.Value) error {
+func (tx *flatTx) Put(ctx context.Context, k kv.Key, v kv.Value) error {
 	if !tx.rw {
 		return kv.ErrReadOnly
 	}
-	return tx.tx.Put(tx.key(k), v)
+	return tx.tx.Put(ctx, tx.key(k), v)
 }
 
-func (tx *flatTx) Del(k kv.Key) error {
+func (tx *flatTx) Del(ctx context.Context, k kv.Key) error {
 	if !tx.rw {
 		return kv.ErrReadOnly
 	}
-	return tx.tx.Del(tx.key(k))
+	return tx.tx.Del(ctx, tx.key(k))
 }
 
-func (tx *flatTx) Scan(opts ...kv.IteratorOption) kv.Iterator {
+func (tx *flatTx) Scan(ctx context.Context, opts ...kv.IteratorOption) kv.Iterator {
 	var (
 		native   []IteratorOption
 		fallback []kv.IteratorOption
@@ -154,7 +154,7 @@ func (tx *flatTx) Scan(opts ...kv.IteratorOption) kv.Iterator {
 			fallback = append(fallback, opt)
 		}
 	}
-	it := &prefIter{kv: tx.kv, Iterator: tx.tx.Scan(native...)}
+	it := &prefIter{kv: tx.kv, Iterator: tx.tx.Scan(ctx, native...)}
 	return kv.ApplyIteratorOptions(it, fallback)
 }
 

--- a/kv/helpers.go
+++ b/kv/helpers.go
@@ -7,7 +7,7 @@ import "context"
 func Update(ctx context.Context, kv KV, update func(tx Tx) error) error {
 	for {
 		err := func() error {
-			tx, err := kv.Tx(true)
+			tx, err := kv.Tx(ctx, true)
 			if err != nil {
 				return err
 			}
@@ -29,7 +29,7 @@ func Update(ctx context.Context, kv KV, update func(tx Tx) error) error {
 
 // View is a helper to open a read-only transaction to read the database.
 func View(ctx context.Context, kv KV, view func(tx Tx) error) error {
-	tx, err := kv.Tx(false)
+	tx, err := kv.Tx(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func View(ctx context.Context, kv KV, view func(tx Tx) error) error {
 // Each is a helper to enumerate all key-value pairs with a specific prefix.
 // See Iterator for rules of using returned values.
 func Each(ctx context.Context, tx Tx, fnc func(k Key, v Value) error, opts ...IteratorOption) error {
-	it := tx.Scan(opts...)
+	it := tx.Scan(ctx, opts...)
 	defer it.Close()
 	for it.Next(ctx) {
 		if err := fnc(it.Key(), it.Val()); err != nil {
@@ -55,8 +55,8 @@ func Each(ctx context.Context, tx Tx, fnc func(k Key, v Value) error, opts ...It
 }
 
 // CreateBucket is a helper to create buckets upfront without writing any key-value pairs to it.
-func CreateBucket(_ context.Context, tx Tx, key Key) error {
+func CreateBucket(ctx context.Context, tx Tx, key Key) error {
 	key = key.Clone()
 	key = append(key, nil)
-	return tx.Put(key, nil)
+	return tx.Put(ctx, key, nil)
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -22,7 +22,7 @@ var (
 // KV is an interface for hierarchical key-value databases.
 type KV interface {
 	base.DB
-	Tx(rw bool) (Tx, error)
+	Tx(ctx context.Context, rw bool) (Tx, error)
 	View(ctx context.Context, fn func(tx Tx) error) error
 	Update(ctx context.Context, fn func(tx Tx) error) error
 }
@@ -157,11 +157,11 @@ type Tx interface {
 	// Put writes a key-value pair to the database.
 	// New value will immediately be visible by Get on the same Tx,
 	// but implementation might buffer the write until transaction is committed.
-	Put(k Key, v Value) error
+	Put(ctx context.Context, k Key, v Value) error
 	// Del removes the key from the database. See Put for consistency guaranties.
-	Del(k Key) error
+	Del(ctx context.Context, k Key) error
 	// Scan starts iteration over key-value pairs. Returned results are affected by IteratorOption.
-	Scan(opts ...IteratorOption) Iterator
+	Scan(ctx context.Context, opts ...IteratorOption) Iterator
 }
 
 // GetBatch is an implementation of Tx.GetBatch for databases that has no native implementation for it.

--- a/kv/kvtest/helpers.go
+++ b/kv/kvtest/helpers.go
@@ -19,10 +19,11 @@ type Test struct {
 }
 
 func (t Test) Get(key kv.Key) (kv.Value, error) {
-	tx, err := t.db.Tx(false)
+	ctx := context.Background()
+	tx, err := t.db.Tx(ctx, false)
 	require.NoError(t.t, err)
 	defer tx.Close()
-	return tx.Get(context.TODO(), key)
+	return tx.Get(ctx, key)
 }
 
 func (t Test) NotExists(k kv.Key) {
@@ -38,13 +39,13 @@ func (t Test) Expect(k kv.Key, exp kv.Value) {
 }
 
 func (t Test) Put(key kv.Key, val kv.Value) {
-	tx, err := t.db.Tx(true)
+	ctx := context.Background()
+	tx, err := t.db.Tx(ctx, true)
 	require.NoError(t.t, err)
 	defer tx.Close()
-	err = tx.Put(key, val)
+	err = tx.Put(ctx, key, val)
 	require.NoError(t.t, err)
 
-	ctx := context.TODO()
 	got, err := tx.Get(ctx, key)
 	require.NoError(t.t, err)
 	require.Equal(t.t, val, got)
@@ -53,14 +54,14 @@ func (t Test) Put(key kv.Key, val kv.Value) {
 }
 
 func (t Test) Del(key kv.Key) {
-	tx, err := t.db.Tx(true)
+	ctx := context.Background()
+	tx, err := t.db.Tx(ctx, true)
 	require.NoError(t.t, err)
 	defer tx.Close()
 
-	err = tx.Del(key)
+	err = tx.Del(ctx, key)
 	require.NoError(t.t, err)
 
-	ctx := context.TODO()
 	got, err := tx.Get(ctx, key)
 	require.Equal(t.t, kv.ErrNotFound, err)
 	require.Equal(t.t, kv.Value(nil), got)
@@ -73,7 +74,7 @@ func (t Test) ExpectIt(it kv.Iterator, exp []kv.Pair) {
 	if len(exp) == 0 {
 		exp = nil
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	var got []kv.Pair
 	for it.Next(ctx) {
 		got = append(got, kv.Pair{
@@ -86,11 +87,12 @@ func (t Test) ExpectIt(it kv.Iterator, exp []kv.Pair) {
 }
 
 func (t Test) Scan(exp []kv.Pair, opts ...kv.IteratorOption) {
-	tx, err := t.db.Tx(false)
+	ctx := context.Background()
+	tx, err := t.db.Tx(ctx, false)
 	require.NoError(t.t, err)
 	defer tx.Close()
 
-	it := tx.Scan(opts...)
+	it := tx.Scan(ctx, opts...)
 	defer it.Close()
 	require.NoError(t.t, it.Err())
 
@@ -98,11 +100,12 @@ func (t Test) Scan(exp []kv.Pair, opts ...kv.IteratorOption) {
 }
 
 func (t Test) ScanReset(exp []kv.Pair, opts ...kv.IteratorOption) {
-	tx, err := t.db.Tx(false)
+	ctx := context.Background()
+	tx, err := t.db.Tx(ctx, false)
 	require.NoError(t.t, err)
 	defer tx.Close()
 
-	it := tx.Scan(opts...)
+	it := tx.Scan(ctx, opts...)
 	defer it.Close()
 	require.NoError(t.t, it.Err())
 

--- a/kv/kvtest/kvtest.go
+++ b/kv/kvtest/kvtest.go
@@ -126,22 +126,23 @@ func readonly(t testing.TB, db kv.KV) {
 
 	nokey := kv.Key{[]byte("b")}
 
-	tx, err := db.Tx(false)
+	ctx := context.Background()
+	tx, err := db.Tx(ctx, false)
 	require.NoError(t, err)
 	defer tx.Close()
 
 	// writing anything on read-only tx must fail
-	err = tx.Put(key, val)
+	err = tx.Put(ctx, key, val)
 	require.Equal(t, kv.ErrReadOnly, err)
-	err = tx.Put(nokey, val)
+	err = tx.Put(ctx, nokey, val)
 	require.Equal(t, kv.ErrReadOnly, err)
 
 	// deleting records on read-only tx must fail
-	err = tx.Del(key)
+	err = tx.Del(ctx, key)
 	require.Equal(t, kv.ErrReadOnly, err)
 
 	// deleting non-existed record on read-only tx must still fail
-	err = tx.Del(nokey)
+	err = tx.Del(ctx, nokey)
 	require.Equal(t, kv.ErrReadOnly, err)
 }
 
@@ -164,15 +165,14 @@ func seek(t testing.TB, db kv.KV) {
 		all = append(all, kv.Pair{Key: k, Val: v})
 	}
 
-	tx, err := db.Tx(false)
+	ctx := context.Background()
+	tx, err := db.Tx(ctx, false)
 	require.NoError(t, err)
 	defer tx.Close()
 
-	ctx := context.TODO()
-
 	// start an iterator and check if it can reset
 	// this is the basic requirement for generic seek to work
-	it := tx.Scan()
+	it := tx.Scan(ctx)
 	defer it.Close()
 	td.ExpectIt(it, all)
 	it.Reset()
@@ -255,7 +255,7 @@ func increment(t testing.TB, db kv.KV) {
 				}
 				v++
 				val = []byte(strconv.Itoa(v))
-				return tx.Put(key, val)
+				return tx.Put(ctx, key, val)
 			})
 			if err != nil {
 				errc <- err

--- a/legacy/nosql/couch/couch.go
+++ b/legacy/nosql/couch/couch.go
@@ -4,6 +4,8 @@
 package couch
 
 import (
+	"context"
+
 	_ "github.com/go-kivik/couchdb" // The CouchDB driver
 
 	"github.com/hidal-go/hidalgo/base"
@@ -26,10 +28,10 @@ func init() {
 	})
 }
 
-func CreateCouch(addr, ns string, opt nosql.Options) (nosql.Database, error) {
-	return Dial(true, DriverCouch, addr, ns, opt)
+func CreateCouch(ctx context.Context, addr, ns string, opt nosql.Options) (nosql.Database, error) {
+	return Dial(ctx, true, DriverCouch, addr, ns, opt)
 }
 
-func OpenCouch(addr, ns string, opt nosql.Options) (nosql.Database, error) {
-	return Dial(false, DriverCouch, addr, ns, opt)
+func OpenCouch(ctx context.Context, addr, ns string, opt nosql.Options) (nosql.Database, error) {
+	return Dial(ctx, false, DriverCouch, addr, ns, opt)
 }

--- a/legacy/nosql/couch/pouch.go
+++ b/legacy/nosql/couch/pouch.go
@@ -3,9 +3,12 @@
 package couch
 
 import (
-	_ "github.com/go-kivik/pouchdb" // The PouchDB driver
+	"context"
+
 	"github.com/hidal-go/hidalgo/base"
 	"github.com/hidal-go/hidalgo/legacy/nosql"
+
+	_ "github.com/go-kivik/pouchdb" // The PouchDB driver
 )
 
 const (
@@ -24,10 +27,10 @@ func init() {
 	})
 }
 
-func CreatePouch(addr string, ns string, opt nosql.Options) (nosql.Database, error) {
-	return Dial(true, DriverPouch, addr, ns, opt)
+func CreatePouch(ctx context.Context, addr string, ns string, opt nosql.Options) (nosql.Database, error) {
+	return Dial(ctx, true, DriverPouch, addr, ns, opt)
 }
 
-func OpenPouch(addr string, ns string, opt nosql.Options) (nosql.Database, error) {
-	return Dial(false, DriverPouch, addr, ns, opt)
+func OpenPouch(ctx context.Context, addr string, ns string, opt nosql.Options) (nosql.Database, error) {
+	return Dial(ctx, false, DriverPouch, addr, ns, opt)
 }

--- a/legacy/nosql/couch/test/couchtest.go
+++ b/legacy/nosql/couch/test/couchtest.go
@@ -57,7 +57,7 @@ func CouchVersion(vers string) nosqltest.Database {
 				t.Fatal(err)
 			}
 
-			qs, err := couch.Dial(true, couch.DriverCouch, addr, "test", nil)
+			qs, err := couch.Dial(ctx, true, couch.DriverCouch, addr, "test", nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/legacy/nosql/couch/test/pouchtest.go
+++ b/legacy/nosql/couch/test/pouchtest.go
@@ -4,12 +4,14 @@
 package couchtest
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
 
+	"github.com/go-kivik/kivik"
 	"github.com/hidal-go/hidalgo/legacy/nosql"
 	"github.com/hidal-go/hidalgo/legacy/nosql/couch"
 	"github.com/hidal-go/hidalgo/legacy/nosql/nosqltest"
@@ -35,17 +37,17 @@ func Pouch() nosqltest.Database {
 				}
 			})
 
+			ctx := context.Background()
 			name := fmt.Sprintf("db-%d", rand.Int())
 
-			qs, err := couch.Dial(false, couch.DriverPouch, dir+"/"+name, name, nil)
+			qs, err := couch.Dial(ctx, false, couch.DriverPouch, dir+"/"+name, name, nil)
 			if err != nil {
 				os.RemoveAll(dir)
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
 				qs.Close()
-				ctx := context.TODO()
-				if c, err := kivik.New(ctx, couch.DriverPouch, dir); err == nil {
+				if c, err := kivik.New(couch.DriverPouch, dir); err == nil {
 					_ = c.DestroyDB(ctx, name)
 				}
 			})

--- a/legacy/nosql/elastic/elastic.go
+++ b/legacy/nosql/elastic/elastic.go
@@ -33,8 +33,8 @@ func init() {
 			Local: false, Volatile: false,
 		},
 		Traits: Traits(),
-		Open: func(addr, ns string, opt nosql.Options) (nosql.Database, error) {
-			db, err := Dial(addr, ns, opt)
+		Open: func(ctx context.Context, addr, ns string, opt nosql.Options) (nosql.Database, error) {
+			db, err := Dial(ctx, addr, ns, opt)
 			if err != nil {
 				return nil, err
 			}
@@ -51,7 +51,7 @@ func dialElastic(addr string) (*elastic.Client, error) {
 	return client, nil
 }
 
-func Dial(addr, index string, opt nosql.Options) (*DB, error) {
+func Dial(ctx context.Context, addr, index string, opt nosql.Options) (*DB, error) {
 	client, err := dialElastic(addr)
 	if err != nil {
 		return nil, err
@@ -557,7 +557,7 @@ func (q *Query) One(ctx context.Context) (nosql.Document, error) {
 	return q.c.convDoc(resp.Hits.Hits[0]), nil
 }
 
-func (q *Query) Iterate() nosql.DocIterator {
+func (q *Query) Iterate(ctx context.Context) nosql.DocIterator {
 	qu := q.cli.Scroll(q.ind).Type(q.c.typ)
 	if q.limit > 0 {
 		qu = qu.Size(int(q.limit))

--- a/legacy/nosql/elastic/test/elastictest.go
+++ b/legacy/nosql/elastic/test/elastictest.go
@@ -64,7 +64,7 @@ func ElasticVersion(vers string) nosqltest.Database {
 				t.Fatal(err)
 			}
 
-			db, err := elastic.Dial(addr, "test", nil)
+			db, err := elastic.Dial(ctx, addr, "test", nil)
 			if err != nil {
 				t.Fatal(addr, err)
 			}

--- a/legacy/nosql/mongo/test/mongotest.go
+++ b/legacy/nosql/mongo/test/mongotest.go
@@ -40,14 +40,15 @@ func MongoVersion(vers string) nosqltest.Database {
 			})
 
 			addr := fmt.Sprintf("mongodb://%s", cont.GetHostPort("27017/tcp"))
+			ctx := context.Background()
 			err = pool.Retry(func() error {
 				sess, err := gomongo.NewClient(options.Client().ApplyURI(addr))
 				if err != nil {
 					return err
 				}
-				defer sess.Disconnect(context.TODO())
+				defer sess.Disconnect(ctx)
 
-				err = sess.Connect(context.TODO())
+				err = sess.Connect(ctx)
 
 				if err != nil {
 					return err
@@ -57,7 +58,7 @@ func MongoVersion(vers string) nosqltest.Database {
 			if err != nil {
 				t.Fatal(err)
 			}
-			qs, err := mongo.Dial(addr, "test", nil)
+			qs, err := mongo.Dial(ctx, addr, "test", nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/legacy/nosql/nosql.go
+++ b/legacy/nosql/nosql.go
@@ -192,7 +192,7 @@ type Query interface {
 	// One executes query and returns first document from it.
 	One(ctx context.Context) (Document, error)
 	// Iterate starts an iteration over query results.
-	Iterate() DocIterator
+	Iterate(ctx context.Context) DocIterator
 }
 
 // Update is an update request builder.

--- a/legacy/nosql/nosqltest/nosqltest.go
+++ b/legacy/nosql/nosqltest/nosqltest.go
@@ -27,6 +27,7 @@ func TestNoSQL(t *testing.T, gen Database) {
 		db = gen.Run(t)
 	}
 
+	ctx := context.Background()
 	for _, kt := range keyTypes {
 		t.Run(kt.Name, func(t *testing.T) {
 			for _, c := range testsNoSQLKey {
@@ -37,7 +38,7 @@ func TestNoSQL(t *testing.T, gen Database) {
 						db = gen.Run(t)
 					}
 					c.t(t, tableConf{
-						ctx: context.TODO(),
+						ctx: ctx,
 						db:  db, tr: tr,
 						col: col, kt: kt,
 					})
@@ -274,9 +275,8 @@ func (s docsAndKeys) Swap(i, j int) {
 }
 
 func iterateExpect(t testing.TB, kt keyType, qu nosql.Query, exp []nosql.Document) {
-	ctx := context.TODO()
-
-	it := qu.Iterate()
+	ctx := context.Background()
+	it := qu.Iterate(ctx)
 	defer it.Close()
 	var (
 		got  = make([]nosql.Document, 0, len(exp))
@@ -403,7 +403,7 @@ func testDeleteByKey(t *testing.T, c tableConf) {
 }
 
 func testUpdate(t *testing.T, c tableConf) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	c.ensurePK(t)
 
 	docs := []nosql.Document{
@@ -496,7 +496,7 @@ func testUpdate(t *testing.T, c tableConf) {
 }
 
 func testDeleteQuery(t *testing.T, c tableConf) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	c.ensurePK(t)
 
 	keys, docs := c.insertDocs(t, 10+len(c.kt.Fields), func(i int) nosql.Document {

--- a/legacy/nosql/registry.go
+++ b/legacy/nosql/registry.go
@@ -1,13 +1,14 @@
 package nosql
 
 import (
+	"context"
 	"sort"
 
 	"github.com/hidal-go/hidalgo/base"
 )
 
 // OpenFunc is a function for opening a database given a address and the database name.
-type OpenFunc func(addr, ns string, opt Options) (Database, error)
+type OpenFunc func(ctx context.Context, addr, ns string, opt Options) (Database, error)
 
 // Registration is an information about the database driver.
 type Registration struct {

--- a/tuple/datastore/datastore.go
+++ b/tuple/datastore/datastore.go
@@ -51,7 +51,7 @@ func (t *tableInfo) Header() tuple.Header {
 	return t.h.Clone()
 }
 
-func (t *tableInfo) Open(tx tuple.Tx) (tuple.Table, error) {
+func (t *tableInfo) Open(ctx context.Context, tx tuple.Tx) (tuple.Table, error) {
 	dtx, ok := tx.(*Tx)
 	if !ok {
 		return nil, fmt.Errorf("datastore: unexpected tx type: %T", tx)
@@ -92,7 +92,7 @@ func (s *TupleStore) ListTables(ctx context.Context) ([]tuple.TableInfo, error) 
 	return out, nil
 }
 
-func (s *TupleStore) Tx(rw bool) (tuple.Tx, error) {
+func (s *TupleStore) Tx(ctx context.Context, rw bool) (tuple.Tx, error) {
 	return &Tx{s: s, rw: rw}, nil
 }
 
@@ -129,7 +129,7 @@ func (tx *Tx) Table(ctx context.Context, name string) (tuple.Table, error) {
 	if err != nil {
 		return nil, err
 	}
-	return info.Open(tx)
+	return info.Open(ctx, tx)
 }
 
 func (tx *Tx) ListTables(ctx context.Context) ([]tuple.Table, error) {
@@ -139,7 +139,7 @@ func (tx *Tx) ListTables(ctx context.Context) ([]tuple.Table, error) {
 	}
 	out := make([]tuple.Table, 0, len(tables))
 	for _, t := range tables {
-		tbl, err := t.Open(tx)
+		tbl, err := t.Open(ctx, tx)
 		if err != nil {
 			return out, err
 		}
@@ -188,8 +188,8 @@ func (tbl *Table) Header() tuple.Header {
 	return tbl.h.Clone()
 }
 
-func (tbl *Table) Open(tx tuple.Tx) (tuple.Table, error) {
-	return (&tableInfo{h: tbl.h}).Open(tx)
+func (tbl *Table) Open(ctx context.Context, tx tuple.Tx) (tuple.Table, error) {
+	return (&tableInfo{h: tbl.h}).Open(ctx, tx)
 }
 
 func (tbl *Table) cli() *datastore.Client {
@@ -554,7 +554,7 @@ func (tbl *Table) DeleteTuplesByKey(ctx context.Context, keys []tuple.Key) error
 	return tbl.cli().DeleteMulti(ctx, dkeys)
 }
 
-func (tbl *Table) Scan(opt *tuple.ScanOptions) tuple.Iterator {
+func (tbl *Table) Scan(ctx context.Context, opt *tuple.ScanOptions) tuple.Iterator {
 	if opt == nil {
 		opt = &tuple.ScanOptions{}
 	}

--- a/tuple/helpers.go
+++ b/tuple/helpers.go
@@ -6,7 +6,7 @@ import (
 
 // Update is a helper to open a read-write transaction and update the database.
 func Update(ctx context.Context, s Store, update func(tx Tx) error) error {
-	tx, err := s.Tx(true)
+	tx, err := s.Tx(ctx, true)
 	if err != nil {
 		return err
 	}
@@ -22,8 +22,8 @@ func Update(ctx context.Context, s Store, update func(tx Tx) error) error {
 }
 
 // View is a helper to open a read-only transaction to read the database.
-func View(_ context.Context, s Store, view func(tx Tx) error) error {
-	tx, err := s.Tx(false)
+func View(ctx context.Context, s Store, view func(tx Tx) error) error {
+	tx, err := s.Tx(ctx, false)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ type Deleter interface {
 
 func DeleteEach(ctx context.Context, d Deleter, f *Filter) error {
 	// TODO: recognize fixed filters
-	it := d.Scan(&ScanOptions{
+	it := d.Scan(ctx, &ScanOptions{
 		KeysOnly: true,
 		Filter:   f,
 	})

--- a/tuple/stats.go
+++ b/tuple/stats.go
@@ -17,7 +17,7 @@ func TableSize(ctx context.Context, t Table, f *Filter, exact bool) (int64, erro
 	if !exact {
 		return 1000, ErrWildGuess
 	}
-	it := t.Scan(&ScanOptions{
+	it := t.Scan(ctx, &ScanOptions{
 		KeysOnly: true,
 		Filter:   f,
 	})

--- a/tuple/tuple.go
+++ b/tuple/tuple.go
@@ -223,7 +223,7 @@ type Tuple struct {
 type Store interface {
 	base.DB
 	// Tx opens a read-only or read-write transaction in the tuple store.
-	Tx(rw bool) (Tx, error)
+	Tx(ctx context.Context, rw bool) (Tx, error)
 	// View provides functional-style read-only transactional access the tuple store.
 	View(ctx context.Context, view func(tx Tx) error) error
 	// Update provides functional-style read-write transactional access to the tuple store.
@@ -264,7 +264,7 @@ type ScanOptions struct {
 
 type Scanner interface {
 	// Scan iterates over all tuples matching specific parameters.
-	Scan(opt *ScanOptions) Iterator
+	Scan(ctx context.Context, opt *ScanOptions) Iterator
 }
 
 // TableInfo represent a metadata of a tuple table.
@@ -272,7 +272,7 @@ type TableInfo interface {
 	// Header returns a tuple header used in this table.
 	Header() Header
 	// Open binds a table to the transaction and opens it for further operations.
-	Open(tx Tx) (Table, error)
+	Open(ctx context.Context, tx Tx) (Table, error)
 }
 
 // Table represents an opened tuples table with a specific type (schema).
@@ -297,6 +297,8 @@ type Table interface {
 	UpdateTuple(ctx context.Context, t Tuple, opt *UpdateOpt) error
 	// DeleteTuples removes all tuples that matches a filter.
 	DeleteTuples(ctx context.Context, f *Filter) error
+
+	// Scanner adds the Scan function.
 	Scanner
 }
 

--- a/tuple/tupletest/tupletest.go
+++ b/tuple/tupletest/tupletest.go
@@ -41,7 +41,7 @@ func RunTest(t *testing.T, fnc Func, opts *Options) {
 		kvtest.RunTest(t, func(t testing.TB) hkv.KV {
 			db := fnc(t)
 
-			ctx := context.TODO()
+			ctx := context.Background()
 			kdb, err := tuplekv.NewKV(ctx, db, "kv")
 			if err != nil {
 				require.NoError(t, err)
@@ -69,11 +69,11 @@ var testList = []struct {
 }
 
 func basic(t *testing.T, db tuple.Store) {
-	tx, err := db.Tx(true)
+	ctx := context.Background()
+	tx, err := db.Tx(ctx, true)
 	require.NoError(t, err)
 	defer tx.Close()
 
-	ctx := context.TODO()
 	tbl, err := tx.CreateTable(ctx, tuple.Header{
 		Name: "test",
 		Key: []tuple.KeyField{
@@ -96,7 +96,7 @@ func basic(t *testing.T, db tuple.Store) {
 	require.NoError(t, err)
 	require.Equal(t, v1, v2)
 
-	it := tbl.Scan(&tuple.ScanOptions{Sort: tuple.SortAsc})
+	it := tbl.Scan(ctx, &tuple.ScanOptions{Sort: tuple.SortAsc})
 	defer it.Close()
 
 	var tuples []tuple.Tuple
@@ -112,7 +112,8 @@ func basic(t *testing.T, db tuple.Store) {
 }
 
 func typed(t *testing.T, db tuple.Store) {
-	tx, err := db.Tx(true)
+	ctx := context.Background()
+	tx, err := db.Tx(ctx, true)
 	require.NoError(t, err)
 	defer tx.Close()
 
@@ -160,7 +161,6 @@ func typed(t *testing.T, db tuple.Store) {
 		})
 	}
 
-	ctx := context.TODO()
 	tbl1, err := tx.CreateTable(ctx, tuple.Header{
 		Name: "test1", Key: kfields1, Data: vfields,
 	})
@@ -188,7 +188,7 @@ func typed(t *testing.T, db tuple.Store) {
 	require.NoError(t, err, "\nkey : %#v\ndata: %#v", kfields, vfields)
 	require.Equal(t, data, v2, "\n%v\nvs\n%v", data, v2)
 
-	it := tbl.Scan(&tuple.ScanOptions{Sort: tuple.SortAsc})
+	it := tbl.Scan(ctx, &tuple.ScanOptions{Sort: tuple.SortAsc})
 	defer it.Close()
 
 	var tuples []tuple.Tuple
@@ -204,11 +204,11 @@ func typed(t *testing.T, db tuple.Store) {
 }
 
 func scans(t *testing.T, db tuple.Store) {
-	tx, err := db.Tx(true)
+	ctx := context.Background()
+	tx, err := db.Tx(ctx, true)
 	require.NoError(t, err)
 	defer tx.Close()
 
-	ctx := context.TODO()
 	tbl, err := tx.CreateTable(ctx, tuple.Header{
 		Name: "test",
 		Key: []tuple.KeyField{
@@ -253,7 +253,7 @@ func scans(t *testing.T, db tuple.Store) {
 		if kpref != nil {
 			f = &tuple.Filter{KeyFilter: kpref}
 		}
-		it := tbl.Scan(&tuple.ScanOptions{Sort: tuple.SortAsc, Filter: f})
+		it := tbl.Scan(ctx, &tuple.ScanOptions{Sort: tuple.SortAsc, Filter: f})
 		defer it.Close()
 
 		var got []int
@@ -329,7 +329,7 @@ func tablesSimple(t testing.TB, db tuple.Store) {
 	}
 
 	newTx := func(rw bool) tuple.Tx {
-		tx, err := db.Tx(rw)
+		tx, err := db.Tx(ctx, rw)
 		require.NoError(t, err)
 		return tx
 	}
@@ -416,7 +416,7 @@ func tablesAuto(t testing.TB, db tuple.Store) {
 	}
 
 	newTx := func(rw bool) tuple.Tx {
-		tx, err := db.Tx(rw)
+		tx, err := db.Tx(ctx, rw)
 		require.NoError(t, err)
 		return tx
 	}
@@ -441,11 +441,11 @@ func tablesAuto(t testing.TB, db tuple.Store) {
 }
 
 func auto(t *testing.T, db tuple.Store) {
-	tx, err := db.Tx(true)
+	ctx := context.Background()
+	tx, err := db.Tx(ctx, true)
 	require.NoError(t, err)
 	defer tx.Close()
 
-	ctx := context.TODO()
 	tbl, err := tx.CreateTable(ctx, tuple.Header{
 		Name: "test",
 		Key: []tuple.KeyField{
@@ -469,7 +469,7 @@ func auto(t *testing.T, db tuple.Store) {
 	require.NoError(t, err)
 	require.Equal(t, v1, v2)
 
-	it := tbl.Scan(&tuple.ScanOptions{Sort: tuple.SortAsc})
+	it := tbl.Scan(ctx, &tuple.ScanOptions{Sort: tuple.SortAsc})
 	defer it.Close()
 
 	var tuples []tuple.Tuple


### PR DESCRIPTION
Add context parameters to eliminate many instances of context.TODO and improve code consistency.

Drop a flaky test (increment).

cc @dennwc 

By the way: this is part of a larger refactor of cayley at https://github.com/aperturerobotics/cayley - any plans to continue work on cayley? Anything I've done in that branch that seems useful @dennwc ? thanks for your hard work on this.